### PR TITLE
Fix environment variables and chatbot initialization

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -121,7 +121,7 @@ def ensure_appdata_scaffold() -> None:
         template = (
             "# Cal RAG Agent configuration\n"
             "# Fill in your API key if using OpenAI models.\n"
-            "MODEL_CHOICE=gpt-4.1-mini\n"
+            "MODEL_CHOICE=gpt-4o-mini\n"
             "OPENAI_API_KEY=\n"
             "# Embeddings backend: sentence (default) or openai\n"
             "EMBEDDING_BACKEND=sentence\n"
@@ -191,7 +191,7 @@ def sanitize_and_validate_openai_key() -> None:
 
     - Do not read from repo .env; only environment or OPENAI_API_KEY_FILE if provided by platform.
     - Trim whitespace and quotes; persist sanitized value to os.environ.
-    - Validate prefix: sk-live- or sk-proj-; on invalid, record error for readiness gate.
+    - Validate prefix: accepts sk-, sk-live-, or sk-proj-; on invalid, record error for readiness gate.
     - Record masked prefix (first 5 chars + '…') for diagnostics only; never log full key.
     """
     global _KEY_SANITIZED_PREFIX, _KEY_VALIDATED, _KEY_VALIDATION_ERROR
@@ -214,10 +214,10 @@ def sanitize_and_validate_openai_key() -> None:
             _KEY_VALIDATION_ERROR = "OPENAI_API_KEY missing"
             _KEY_SANITIZED_PREFIX = ""
             return
-        # Prefix validation
-        if not (key.startswith("sk-live-") or key.startswith("sk-proj-")):
+        # Prefix validation - accept standard sk- as well as sk-live- and sk-proj-
+        if not key.startswith("sk-"):
             _KEY_VALIDATED = False
-            _KEY_VALIDATION_ERROR = "OPENAI_API_KEY has unexpected prefix"
+            _KEY_VALIDATION_ERROR = "OPENAI_API_KEY has unexpected prefix (should start with sk-)"
         else:
             _KEY_VALIDATED = True
             _KEY_VALIDATION_ERROR = ""


### PR DESCRIPTION
This commit addresses all critical issues preventing the chatbot from running in local environments:

1. Environment file loading (.env):
   - Modified streamlit_app.py and rag_agent.py to load repo .env first before falling back to ~/.calrag/.env
   - Ensures local OpenAI API keys are properly picked up

2. OpenAI API key validation (utils.py):
   - Relaxed validation to accept standard sk- prefixes in addition to sk-live- and sk-proj-
   - Fixes rejection of valid OpenAI API keys from platform.openai.com

3. Embedding warmup handling (streamlit_app.py):
   - Made embedding warmup graceful with warning instead of stopping app
   - Prevents crashes on clean machines without torch/sentence-transformers caches

4. RAGDeps dataclass (rag_agent.py):
   - Added collection_name and vector_backend fields to RAGDeps
   - Fixes AttributeError when UI tries to display collection_name

5. Vector search functionality (utils_vectorstore.py):
   - Fixed ChromaVectorStore.vector_search() to use query_embeddings parameter
   - Ensures user queries actually influence search results instead of empty string queries

6. Model selection (rag_agent.py, streamlit_app.py, utils.py):
   - Changed default model from non-existent gpt-4.1-mini to valid gpt-4o-mini
   - Prevents 404/model-not-found errors from OpenAI API

7. BigQuery graceful fallback (utils_vectorstore.py):
   - Added graceful error handling when BigQuery credentials are missing
   - Automatically falls back to ChromaDB instead of crashing

All changes maintain backward compatibility while ensuring the chatbot can boot, authenticate, embed queries, and retrieve correct context in local development environments.